### PR TITLE
臺灣地區用語修正

### DIFF
--- a/bopomofo_tw.schema.yaml
+++ b/bopomofo_tw.schema.yaml
@@ -19,9 +19,9 @@ schema:
 switches:
   - name: ascii_mode
     reset: 0
-    states: [ 中文, 西文 ]
+    states: [ 中文, 英文 ]
   - name: full_shape
-    states: [ 半角, 全角 ]
+    states: [ 半形, 全形 ]
   - name: ascii_punct
     states: [ 。，, ．， ]
   - name: zh_tw


### PR DESCRIPTION
臺灣地區比較少人使用全角和半角這種說法，而是使用全形和半形。
"西文"是指"西班牙語"，而"英文"在臺灣地區是指美國或英國所使用的語言。
